### PR TITLE
prepared bash daemon

### DIFF
--- a/client/firefox/startup.sh
+++ b/client/firefox/startup.sh
@@ -15,4 +15,5 @@ fi;
 cd /usr/src/tests/tests
 
 composer install --prefer-dist
-vendor/bin/robo run:container-tests
+vendor/bin/robo run:container-test-preparation
+tail -f /dev/null


### PR DESCRIPTION
By adding the tail -f command, the container won't stop automatically after the robo command finished. It is a reliable way to reuse the container for multiple tests.